### PR TITLE
Add sqlalchemy version 1.0.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.11" %}
+{% set version = "1.0.19" %}
 
 package:
   name: sqlalchemy
@@ -6,8 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-{{ version }}.tar.gz
-  sha256: ef6569ad403520ee13e180e1bfd6ed71a0254192a934ec1dbd3dbf48f4aa9524
-
+  sha256: 7dbca608466796816fda85282b9c90b9e0897805f4210450f18f9c2c8eee9eb5
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .


### PR DESCRIPTION
Hi @ocefpaf @mcs07 @nehaljwani @igortg ,

unfortunately we are stuck with the old 1.0.19 version of sqlalchemy which I couldn't find
on conda / conda-forge, so I provided a meta.yaml file for this version based on your recipe. It would be greatly appreciated if one of you could review and merge this version into the feedstock. If there's anything in the recipe you would like to have changed please let me know.

Best,
Andreas